### PR TITLE
Repositories: delete deployment

### DIFF
--- a/github/repos_deployments.go
+++ b/github/repos_deployments.go
@@ -129,6 +129,18 @@ func (s *RepositoriesService) CreateDeployment(ctx context.Context, owner, repo 
 	return d, resp, nil
 }
 
+// DeleteDeployment deletes an existing deployment for a repository.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/deployments/#delete-a-deployment
+func (s *RepositoriesService) DeleteDeployment(ctx context.Context, owner, repo string, deploymentID int64) (*Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/deployments/%v", owner, repo, deploymentID)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
 // DeploymentStatus represents the status of a
 // particular deployment.
 type DeploymentStatus struct {

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -101,6 +101,14 @@ func TestRepositoriesService_DeleteDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Repositories.DeleteDeployment returned error: %v", err)
 	}
+
+	resp, err := client.Repositories.DeleteDeployment(context.Background(), "o", "r", 2)
+	if err == nil {
+		t.Error("Repositories.DeleteDeployment should return an error")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Error("Repositories.DeleteDeployment should return a 404 status")
+	}
 }
 
 func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {

--- a/github/repos_deployments_test.go
+++ b/github/repos_deployments_test.go
@@ -89,6 +89,20 @@ func TestRepositoriesService_CreateDeployment(t *testing.T) {
 	}
 }
 
+func TestRepositoriesService_DeleteDeployment(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/deployments/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Repositories.DeleteDeployment(context.Background(), "o", "r", 1)
+	if err != nil {
+		t.Errorf("Repositories.DeleteDeployment returned error: %v", err)
+	}
+}
+
 func TestRepositoriesService_ListDeploymentStatuses(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
Add support for the deleteDeployment action on the Repositories API.
https://developer.github.com/v3/repos/deployments/#delete-a-deployment